### PR TITLE
Bump supported shell versions to 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "settings-schema": "org.gnome.shell.extensions.inputmethod-shortcuts",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/osamuaoki/inputmethod-shortcuts",
   "uuid": "inputmethod-shortcuts@osamu.debian.org"


### PR DESCRIPTION
It seems that no code change is required, just bumping the supported version to 47 made it work for me on Fedora 41. Everything seems to be working fine.