### PR TITLE
Bump supported shell version to 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/osamuaoki/inputmethod-shortcuts",
   "uuid": "inputmethod-shortcuts@osamu.debian.org"


### PR DESCRIPTION
I tested locally (the features I use, Fedora 42) and it seems to work fine.