### PR TITLE
Bump supported shell versions to 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/osamuaoki/inputmethod-shortcuts",
   "uuid": "inputmethod-shortcuts@osamu.debian.org"


### PR DESCRIPTION
Fixes https://github.com/osamuaoki/inputmethod-shortcuts/issues/11.
